### PR TITLE
Changed from singleton to bind

### DIFF
--- a/src/Providers/TableDiffServiceProvider.php
+++ b/src/Providers/TableDiffServiceProvider.php
@@ -21,7 +21,7 @@ class TableDiffServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(TableDiff::class, function ($app) {
+        $this->app->bind(TableDiff::class, function ($app) {
             return new TableDiff();
         });
     }


### PR DESCRIPTION
Needed to be done because this library becomes unstable when doing multiple merges in the same execution process due to the singleton instantiation of the class. Using bind will re-instantiate the class every time it's called instead of returning the same class.